### PR TITLE
Fix: `TypeError: UE.getEditor is not a function` issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ hook调用会在UE加载完成后，UEditor初始化前调用，而且这个整�
 ```typescript
 UEditorModule.forRoot({
     js: [
-      `./assets/ueditor/ueditor.all.min.js`,
       `./assets/ueditor/ueditor.config.js`,
+      `./assets/ueditor/ueditor.all.min.js`,
     ],
     // 默认前端配置项
     options: {

--- a/README.md
+++ b/README.md
@@ -28,15 +28,18 @@ npm install ngx-ueditor --save
 把 `UEditorModule` 模块导入到你项目中。
 
 ```typescript
+import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
 import { UEditorModule } from 'ngx-ueditor';
 
 @NgModule({
   imports: [ 
     BrowserModule,
+    FormsModule,
     UEditorModule.forRoot({
       js: [
-        `./assets/ueditor/ueditor.all.min.js`,
         `./assets/ueditor/ueditor.config.js`,
+        `./assets/ueditor/ueditor.all.min.js`,
       ],
       // 默认前端配置项
       options: {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -34,8 +34,8 @@ import {
 
     UEditorModule.forRoot({
       js: [
-        `./assets/ueditor/ueditor.all.min.js`,
         `./assets/ueditor/ueditor.config.js`,
+        `./assets/ueditor/ueditor.all.min.js`,
       ],
       options: {
         zIndex: 5000,


### PR DESCRIPTION
多亏这个项目，可以在NG程序里集成靠谱的富文本编辑器。在用的时候发现一些小问题，想可能其他人也遇到了同样的[问题](https://github.com/cipchk/ngx-ueditor/issues/38)，就顺便贡献自己的一份力量，修复了`TypeError: UE.getEditor is not a function` 问题，详情请参照[这里](https://blog.csdn.net/tsinghuahui/article/details/47113199)， 望采纳。